### PR TITLE
docs: clarify PyMuPDF AGPL-3.0 obligation under MIT project

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,47 @@
+# Third-Party Notices
+
+RetainPDF's own source code is licensed under the MIT License (see `LICENSE`).
+
+However, this project depends at runtime on third-party components under
+their own licenses. When you distribute binaries or Docker images built from
+this repository, the combined work is subject to those licenses as well.
+
+## PyMuPDF (AGPL-3.0) — IMPORTANT
+
+- Package: `PyMuPDF==1.26.5` (`pyproject.toml`), imported as `fitz` in
+  30+ files across the render path, e.g.
+  `backend/scripts/services/rendering/typst/page_ops.py`
+  (`show_pdf_page(overlay=True)`),
+  `backend/scripts/services/rendering/redaction/redaction_fill.py`,
+  `backend/scripts/services/rendering/typst/overlay_ops.py`,
+  `backend/scripts/services/rendering/background/*`.
+- License: Dual Licensed — GNU AFFERO General Public License v3.0 (AGPL-3.0)
+  OR Artifex Commercial License.
+- Upstream: https://github.com/pymupdf/PyMuPDF/blob/main/COPYING
+- License text: https://www.gnu.org/licenses/agpl-3.0.en.html
+- Commercial licensing: https://artifex.com/licensing
+
+What this means (non-legal summary):
+
+- MIT covers RetainPDF's own files only; it does not override AGPL on the
+  `PyMuPDF` dependency.
+- If you distribute builds/images containing PyMuPDF (desktop installers,
+  `docker/delivery/`, Docker Hub images), the combined distribution must
+  comply with AGPL-3.0 §§4–6 (Corresponding Source + license notices) and
+  §13 (network use source offer), unless you obtained a commercial license
+  from Artifex.
+- Closed-source distributors must either buy a commercial PyMuPDF license
+  or replace the `fitz`-based PDF ops layer (e.g. with
+  https://github.com/pypdfium2-team/pypdfium2 behind an interface).
+
+## Other bundled runtime components
+
+- Typst (external binary, `pyproject.toml [tool.retain_pdf.external-binaries]`):
+  Apache-2.0 — https://github.com/typst/typst
+- pikepdf 7.2.0: MPL-2.0 — https://github.com/pikepdf/pikepdf
+- Pillow 10.4.0: HPND (permissive) — https://github.com/python-pillow/Pillow
+- pdf-lib / pdf.js (frontend preview & compare merge): Apache-2.0 / MIT
+- Source Han Serif SC fonts (`backend/fonts/`): SIL OFL 1.1
+
+If in doubt, consult a lawyer. Only the copyright holders (e.g. Artifex for
+PyMuPDF/MuPDF) can grant exceptions or enforce their licenses.

--- a/README.md
+++ b/README.md
@@ -242,4 +242,12 @@ Feel free to open an issue or submit a pull request.
 
 ## 📄 License
 
-This project is licensed under the [MIT License](LICENSE).
+This project's own source code is licensed under the [MIT License](LICENSE).
+
+> ⚠️ **Third-party license note:** runtime distributions also include
+> `PyMuPDF` (`AGPL-3.0 OR Artifex Commercial`), imported as `fitz` across the
+> render path (`rendering/typst/page_ops.py`, `rendering/redaction/*`). MIT on
+> our files does not override AGPL on that dependency. Distributing binaries /
+> Docker images containing PyMuPDF requires AGPL §§4–6 + §13 compliance
+> (Corresponding Source + notices), unless you hold a commercial PyMuPDF
+> license. See [NOTICE](NOTICE) for details.

--- a/README_zh.md
+++ b/README_zh.md
@@ -207,4 +207,6 @@ retain-pdf/
 
 ## 开源协议
 
-本项目采用 [MIT License](LICENSE) 开源协议。
+本项目自身源代码采用 [MIT License](LICENSE) 开源协议。
+
+> ⚠️ **第三方许可说明：** 运行时分发物还包含 `PyMuPDF`（`AGPL-3.0 或 Artifex 商业授权`），以 `fitz` 形式被排版渲染链路（`rendering/typst/page_ops.py`、`rendering/redaction/*` 等 30 余处）直接链接调用。自身代码的 MIT 不能覆盖该依赖的 AGPL。分发含 PyMuPDF 的安装包 / Docker 镜像时，须遵守 AGPL §§4–6 + §13（提供对应源码与声明），或持有 Artifex 商业授权。详见 [NOTICE](NOTICE)。


### PR DESCRIPTION
## Summary
Love this project. Filing this as a license-clarity PR, not a code bug.

The repo is MIT (LICENSE), but the core runtime dependency PyMuPDF==1.26.5 (pyproject.toml:8) is Dual Licensed - GNU AFFERO GPL 3.0 or Artifex Commercial License.

import fitz is used in 30+ files across the entire render path, e.g.:

- backend/scripts/services/rendering/typst/page_ops.py:103,149 show_pdf_page(overlay=True)
- backend/scripts/services/rendering/redaction/redaction_fill.py
- backend/scripts/services/rendering/typst/overlay_ops.py, overlay_book.py
- backend/scripts/services/rendering/background/*, preprocess/hidden_text_strip.py

This is library linking into a combined work, not a standalone typst-style binary call.

## Why this matters
MIT is AGPL-compatible, so MIT files depending on an AGPL lib is allowed in principle. But the combined work when conveyed must comply with AGPL.

Currently:
1. Only MIT text ships in LICENSE, no AGPL text / NOTICE.
2. Project distributes object code containing PyMuPDF: desktop Setup.exe/.dmg/.deb (README.md:82-86), Docker Hub wxyhgk/retainpdf-app and wxyhgk/retainpdf-web (README.md:135-137), docker/delivery/.
3. Downstream users reusing this as MIT-only for closed-source distribution will unknowingly violate AGPL sections 4-6 and 13.

## This PR does
- Adds NOTICE with PyMuPDF AGPL-3.0 notice + other runtime components (Typst Apache-2.0, pikepdf MPL-2.0, Pillow HPND, fonts OFL).
- Adds a short third-party license warning to README.md and README_zh.md pointing at NOTICE.
- No code change.

Suggested follow-ups for maintainer (pick one, non-legal advice):
1. Keep AGPL path: vendor LICENSES/AGPL-3.0.txt and ensure Docker images carry a source offer.
2. Commercial path: document that closed-source distributors must obtain https://artifex.com/licensing
3. Long-term: abstract PDF ops behind an interface to allow a permissive backend like https://github.com/pypdfium2-team/pypdfium2

## References
- https://pypi.org/project/PyMuPDF/ (License: Dual Licensed - GNU AFFERO GPL 3.0 or Artifex Commercial License)
- https://github.com/pymupdf/PyMuPDF/blob/main/COPYING
- https://www.gnu.org/licenses/agpl-3.0.en.html
- https://artifex.com/licensing

Happy to adjust wording or vendor the full AGPL text under LICENSES/ if you prefer. Thanks for the great work on layout-preserving translation.